### PR TITLE
Use a better format specifier to prevent unintended roundoff

### DIFF
--- a/forcing_tools/netcdf2vic.py
+++ b/forcing_tools/netcdf2vic.py
@@ -174,7 +174,7 @@ def write_ASCII(array, point, out_prefix, path, append, verbose=False):
 
     if verbose:
         print('Writing ASCII Data to'.format(out_file))
-    np.savetxt(f, array, fmt='%1.4f')
+    np.savetxt(f, array, fmt='%12.7g')
     f.close()
 
 


### PR DESCRIPTION
The print statement for writing the ASCII file is 

np.savetxt(f, array, fmt='%1.4f’)

which means that all output will be written with 4 decimals (note that the 1 in this case does nothing, you could have just written %.4f), e.g.

172.0244 0.0000 0.0000 97093.2734 0.0003 248.2306 3.6916

However, because the numbers span a large range, the fixed number of decimals is not a good choice. It is overkill for the pressure (column 4) and insufficient for the precipitation (column 3).

A better choice would be %12.7g or something like it, which would result in 

   172.0244            0            0     97093.27 0.0003061855     248.2306     3.691602

Small precipitation amounts are then written as e.g. 5.655174e-06, a value that would have defaulted to 0 in the original.
