### PR TITLE
Expanded the number of characters in the part of the vic2netcdf.py

### DIFF
--- a/tonic/models/vic/vic2netcdf.py
+++ b/tonic/models/vic/vic2netcdf.py
@@ -894,8 +894,8 @@ def get_file_coords(files):
     points = Plist()
 
     for i, filename in enumerate(files):
-        # fname = path.split(f)[1][-16:] # just look at last 16 characters
-        f = filename[-22:]  # just look at last 16 characters
+        f = filename[-30:]  # Look at last 30 characters of filename to
+			    # find the coordinates in the filename.
         lat, lon = list(map(float, findall(r"[-+]?\d*\.\d+|\d+", f)))[-2:]
         points.append(Point(lat=lat, lon=lon, filename=filename))
 


### PR DESCRIPTION
code that reads filenames to find the coordinates. Before, the
code would break if the output files were at 1/16th degree resolution
because the number of characters of a XX.XXXXX_-XXX.XXXXX would
exceed the counted characters and the coordinate mapping would
fail.